### PR TITLE
Allow user to filter unwanted channels

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -30,7 +30,7 @@ vars:
   path_lookback_days: 30 # Restrict to marketing channels within this many days of the conversion (recommended: 30 / 14 / 7)
   path_transforms: [['Exposure', null]] # array of path transforms (and their arguments) to perform on the full conversion path (see udfs.sql)
   consider_intrasession_channels: false # false = only considers the channel at the start (first page view) of the session, true = consider multiple channels in the conversion session as well as historical channels
-  channels_to_exclude: ['Direct', 'Unmatched_Channel'] # Channels to exclude before creating path summaries (and therefore excluded from fractribution analysis)
+  channels_to_exclude: [] # Channels to exclude before creating path summaries (and therefore excluded from fractribution analysis), e.g. ['Direct']
   use_snowplow_web_user_mapping_table: false # true if using the Snowplow base model for web user mappings (domain_userid => user_id)
 
 # Overwrite these source table vars in your own dbt_project.yml if not using these defaults:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -30,7 +30,7 @@ vars:
   path_lookback_days: 30 # Restrict to marketing channels within this many days of the conversion (recommended: 30 / 14 / 7)
   path_transforms: [['Exposure', null]] # array of path transforms (and their arguments) to perform on the full conversion path (see udfs.sql)
   consider_intrasession_channels: false # false = only considers the channel at the start (first page view) of the session, true = consider multiple channels in the conversion session as well as historical channels
-
+  channels_to_exclude: ['Direct', 'Unmatched_Channel'] # Channels to exclude before creating path summaries (and therefore excluded from fractribution analysis)
   use_snowplow_web_user_mapping_table: false # true if using the Snowplow base model for web user mappings (domain_userid => user_id)
 
 # Overwrite these source table vars in your own dbt_project.yml if not using these defaults:

--- a/macros/channel_classification.sql
+++ b/macros/channel_classification.sql
@@ -7,6 +7,7 @@
     -- each channel should return a name that will also be a valid Snowflake column name
     -- by convention use underscores to separate
     -- (<251 characters, avoid spaces, leading numbers)
+    -- keep Unmatched_Channel as the default value for channels that are not matched by your case statement
 
     CASE
         WHEN

--- a/models/snowflake/snowplow_fractribution_paths_to_conversion.sql
+++ b/models/snowflake/snowplow_fractribution_paths_to_conversion.sql
@@ -20,8 +20,9 @@ SELECT
       {% if arg_str %}, {{arg_str}}{% endif %})
     {% endfor %}
     , ' > ') AS transformedPath
-FROM {{ ref('snowplow_fractribution_conversions_by_customer_id') }} con
-LEFT JOIN {{ ref('snowplow_fractribution_sessions_by_customer_id') }} se
+FROM 
+{{ ref('snowplow_fractribution_sessions_by_customer_id') }} se
+LEFT JOIN {{ ref('snowplow_fractribution_conversions_by_customer_id') }} con
   ON
     con.customerId = se.customerId
     AND DATEDIFF(day, visitStartTimestamp, conversionTimestamp)

--- a/models/snowflake/snowplow_fractribution_sessions_by_customer_id.sql
+++ b/models/snowflake/snowplow_fractribution_sessions_by_customer_id.sql
@@ -57,4 +57,14 @@ WHERE
         -- yields one row per session (last touch)
         AND page_view_in_session_index = 1 -- takes the first page view in the session
     {% endif %}
+    
+    {% if var('channels_to_exclude') %}
+        -- Filters out any unwanted channels
+        AND channel NOT IN (
+            {%- for unwanted_channel in var('channels_to_exclude') %}
+                '{{ unwanted_channel }}'
+                {%- if not loop.last %},{% endif %}
+            {%- endfor %}
+        )
+    {% endif %}
 

--- a/utils/fractribution.py
+++ b/utils/fractribution.py
@@ -20,8 +20,6 @@ import json
 import re
 from typing import Iterable, List, Mapping, Tuple
 
-# Default channel name when no match is found.
-# UNMATCHED_CHANNEL = "Unmatched_Channel"
 
 
 class _PathSummary(object):
@@ -263,7 +261,6 @@ class Fractribution(object):
     def _path_summary_to_json_stringio(self) -> io.BytesIO:
         """Returns a BytesIO file with one JSON-encoded _PathSummary per line."""
 
-        # default_attribution = {UNMATCHED_CHANNEL: 1.0}
         bytesio = io.BytesIO()
         for path_tuple, path_summary in self._path_tuple_to_summary.items():
             row = {
@@ -274,8 +271,6 @@ class Fractribution(object):
             }
             if path_summary.channel_to_attribution:
                 row.update(path_summary.channel_to_attribution)
-            # else:
-            #     row.update(default_attribution)
             bytesio.write(json.dumps(row).encode("utf-8"))
             bytesio.write("\n".encode("utf-8"))
         bytesio.flush()
@@ -284,7 +279,6 @@ class Fractribution(object):
 
     def _path_summary_to_list(self) -> List:
         """Returns a list with list _PathSummary per line."""
-        # default_attribution = {UNMATCHED_CHANNEL: 1.0}
         rows = []
         for path_tuple, path_summary in self._path_tuple_to_summary.items():
             row = {
@@ -295,8 +289,6 @@ class Fractribution(object):
             }
             if path_summary.channel_to_attribution:
                 row.update(path_summary.channel_to_attribution)
-            # else:
-            #     row.update(default_attribution)
             rows.append(row)
 
         return rows
@@ -307,12 +299,10 @@ class Fractribution(object):
         Returns:
           Mapping from channel to overall conversion attribution.
         """
-        # default_attribution = {UNMATCHED_CHANNEL: 1.0}
         overall_channel_to_attribution = {}
         for path_summary in self._path_tuple_to_summary.values():
             channel_to_attribution = path_summary.channel_to_attribution
-            # if not channel_to_attribution:
-            #     channel_to_attribution = default_attribution
+
             for channel, attribution in channel_to_attribution.items():
                 overall_channel_to_attribution[channel] = (
                     overall_channel_to_attribution.get(channel, 0.0)
@@ -326,12 +316,9 @@ class Fractribution(object):
         Returns:
           Mapping from channel to overall revenue attribution.
         """
-        # default_attribution = {UNMATCHED_CHANNEL: 1.0}
         overall_channel_to_revenue = {}
         for path_summary in self._path_tuple_to_summary.values():
             channel_to_attribution = path_summary.channel_to_attribution
-            # if not channel_to_attribution:
-            #     channel_to_attribution = default_attribution
             revenue = path_summary.revenue
             if not revenue:
                 revenue = 0.0

--- a/utils/fractribution.py
+++ b/utils/fractribution.py
@@ -21,7 +21,7 @@ import re
 from typing import Iterable, List, Mapping, Tuple
 
 # Default channel name when no match is found.
-UNMATCHED_CHANNEL = "Unmatched_Channel"
+# UNMATCHED_CHANNEL = "Unmatched_Channel"
 
 
 class _PathSummary(object):
@@ -263,7 +263,7 @@ class Fractribution(object):
     def _path_summary_to_json_stringio(self) -> io.BytesIO:
         """Returns a BytesIO file with one JSON-encoded _PathSummary per line."""
 
-        default_attribution = {UNMATCHED_CHANNEL: 1.0}
+        # default_attribution = {UNMATCHED_CHANNEL: 1.0}
         bytesio = io.BytesIO()
         for path_tuple, path_summary in self._path_tuple_to_summary.items():
             row = {
@@ -274,8 +274,8 @@ class Fractribution(object):
             }
             if path_summary.channel_to_attribution:
                 row.update(path_summary.channel_to_attribution)
-            else:
-                row.update(default_attribution)
+            # else:
+            #     row.update(default_attribution)
             bytesio.write(json.dumps(row).encode("utf-8"))
             bytesio.write("\n".encode("utf-8"))
         bytesio.flush()
@@ -284,7 +284,7 @@ class Fractribution(object):
 
     def _path_summary_to_list(self) -> List:
         """Returns a list with list _PathSummary per line."""
-        default_attribution = {UNMATCHED_CHANNEL: 1.0}
+        # default_attribution = {UNMATCHED_CHANNEL: 1.0}
         rows = []
         for path_tuple, path_summary in self._path_tuple_to_summary.items():
             row = {
@@ -295,8 +295,8 @@ class Fractribution(object):
             }
             if path_summary.channel_to_attribution:
                 row.update(path_summary.channel_to_attribution)
-            else:
-                row.update(default_attribution)
+            # else:
+            #     row.update(default_attribution)
             rows.append(row)
 
         return rows
@@ -307,12 +307,12 @@ class Fractribution(object):
         Returns:
           Mapping from channel to overall conversion attribution.
         """
-        default_attribution = {UNMATCHED_CHANNEL: 1.0}
+        # default_attribution = {UNMATCHED_CHANNEL: 1.0}
         overall_channel_to_attribution = {}
         for path_summary in self._path_tuple_to_summary.values():
             channel_to_attribution = path_summary.channel_to_attribution
-            if not channel_to_attribution:
-                channel_to_attribution = default_attribution
+            # if not channel_to_attribution:
+            #     channel_to_attribution = default_attribution
             for channel, attribution in channel_to_attribution.items():
                 overall_channel_to_attribution[channel] = (
                     overall_channel_to_attribution.get(channel, 0.0)
@@ -326,12 +326,12 @@ class Fractribution(object):
         Returns:
           Mapping from channel to overall revenue attribution.
         """
-        default_attribution = {UNMATCHED_CHANNEL: 1.0}
+        # default_attribution = {UNMATCHED_CHANNEL: 1.0}
         overall_channel_to_revenue = {}
         for path_summary in self._path_tuple_to_summary.values():
             channel_to_attribution = path_summary.channel_to_attribution
-            if not channel_to_attribution:
-                channel_to_attribution = default_attribution
+            # if not channel_to_attribution:
+            #     channel_to_attribution = default_attribution
             revenue = path_summary.revenue
             if not revenue:
                 revenue = 0.0

--- a/utils/main_snowplow_snowflake.py
+++ b/utils/main_snowplow_snowflake.py
@@ -63,8 +63,8 @@ def _extract_channels(client, params: Mapping[str, Any]) -> List[str]:
     """
 
     channels = [row.CHANNEL for row in client]
-    if fractribution.UNMATCHED_CHANNEL not in channels:
-        channels.append(fractribution.UNMATCHED_CHANNEL)
+    # if fractribution.UNMATCHED_CHANNEL not in channels:
+    #     channels.append(fractribution.UNMATCHED_CHANNEL)
     for channel in channels:
         if not _is_valid_column_name(channel):
             raise ValueError("Channel is not a legal Snowflake column name: ", channel)

--- a/utils/main_snowplow_snowflake.py
+++ b/utils/main_snowplow_snowflake.py
@@ -63,8 +63,6 @@ def _extract_channels(client, params: Mapping[str, Any]) -> List[str]:
     """
 
     channels = [row.CHANNEL for row in client]
-    # if fractribution.UNMATCHED_CHANNEL not in channels:
-    #     channels.append(fractribution.UNMATCHED_CHANNEL)
     for channel in channels:
         if not _is_valid_column_name(channel):
             raise ValueError("Channel is not a legal Snowflake column name: ", channel)


### PR DESCRIPTION
<!--
If this is your first time contributing you will be asked to sign the Individual Contributor License Agreement.
If you would prefer to read this in advance of submitting your PR you can find it here https://docs.google.com/forms/d/e/1FAIpQLSd89YTDQ1XpTZbj3LpOkquV_h1Y8k9ay3iFbJsZsJrz18I23Q/viewform
-->

## Description & motivation
<!--

-->
These changes allow a user to filter out unwanted channels, such as Direct, so that they are not used in fractribution analysis.
A couple of points:
-  I have commented out `unmatched_channel` in the python scripts because this caused `unmatched_channel` to be included in the report table with null values even when it was excluded using the variable. @miike can you please have a look at the python files where I've commented out these references to double check they're not needed? It seems to work fine without them.
- i'm not sure if the default for the `channels_to_exclude` variable should be an empty list, or include `direct` etc? 
- Please let me know if I should rename this branch - i'm not sure of the branch naming conventions.

If these changes all seem fine, I can then create PRs to update the accelerator, documentation, readme etc. 
## Checklist
- [ x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)

<!-- 
## Release Only Checklist
- [ ] I have updated the version number in all relevant places
- [ ] I have update the Github pages `dbt docs` 
- [ ] I have updated the CHANGELOG.md 
-->