### PR TITLE
Release/snowplow fractribution/0.3.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+snowplow-fractribution 0.3.2 (2023-07-25)
+---------------------------------------
+## Summary
+This version allows the user to filter their events table using the timestamp field that the table is partitioned on, optimizing query performance.
+
+## Features
+- snowplow_fractribution_conversions_by_customer_id should allow extra filter column with buffer (Close #17)
+
+## Upgrading
+Bump the snowplow-fractribution version in your `packages.yml` file.
+
 snowplow-fractribution 0.3.1 (2023-06-12)
 ---------------------------------------
 ## Summary
@@ -20,7 +31,7 @@ This version migrates our models away from the `snowplow_incremental_materializa
 
 ## 🚨 Breaking Changes 🚨
 ### Changes to materialization
-To take advantage of the optimization we apply to the `incremental` materialization, users will need to add the following to their `dbt_project.yml` : 
+To take advantage of the optimization we apply to the `incremental` materialization, users will need to add the following to their `dbt_project.yml` :
 ```yaml
 # dbt_project.yml
 ...

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -40,7 +40,8 @@ vars:
     # Overwrite these source table vars in your own dbt_project.yml if not using these defaults:
     snowplow__page_views_source: "{{ source('derived', 'snowplow_web_page_views') }}"
     snowplow__conversions_source: "{{ source('atomic', 'events') }}"
-
+    snowplow__conversions_source_filter: '' # a timestamp field the conversion source field is partitioned on (ideally) for optimized filtering, when left blank derived_tstamp is used
+    snowplow__conversions_source_filter_buffer_days: 1 # the number of days to extend the filter
     # snowplow__web_user_mapping_table: derived.snowplow_web_user_mapping # path (schema and table) to the Snowplow web user mapping table
 
     # Snowflake only

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,6 +1,6 @@
 
 name: 'snowplow_fractribution'
-version: '0.3.1'
+version: '0.3.2'
 config-version: 2
 
 require-dbt-version: [">=1.4.0", "<2.0.0"]

--- a/integration_tests/.scripts/integration_test.sh
+++ b/integration_tests/.scripts/integration_test.sh
@@ -34,37 +34,37 @@ for db in ${DATABASES[@]}; do
 
   echo "Snowplow Web: Execute models"
 
-  eval "dbt run --select snowplow_web --target $db --full-refresh --vars '{snowplow__allow_refresh: true}'" || exit 1;
-  
+  eval "dbt run --select snowplow_web --full-refresh --vars '{snowplow__allow_refresh: true}' --target $db" || exit 1;
+
   if [[ $db == "snowflake" ]]; then
     for model in ${ATTRIBUTION_MODELS_TO_TEST[@]}; do
       echo "Snowplow Fractribution integration tests: Execute fractribution models"
 
-      eval "dbt run --select snowplow_fractribution --target $db --full-refresh --vars '{snowplow__attribution_model_for_snowpark: $model}'" || exit 1;
-  
+      eval "dbt run --select snowplow_fractribution --full-refresh --vars '{snowplow__attribution_model_for_snowpark: $model}' --target $db" || exit 1;
+
       echo "Snowplow Fractribution integration tests: Execute fractribution integration test models for $model"
 
-      eval "dbt run --select snowplow_fractribution_integration_tests --target $db --full-refresh --vars '{snowplow__attribution_model_for_snowpark: $model}'" || exit 1;
+      eval "dbt run --select snowplow_fractribution_integration_tests --full-refresh --vars '{snowplow__attribution_model_for_snowpark: $model}' --target $db" || exit 1;
 
       echo "Snowplow Fractribution integration tests: Test models for $model"
 
-      eval "dbt test --target $db --exclude snowplow_web" || exit 1;
-      
+      eval "dbt test --exclude snowplow_web --target $db" || exit 1;
+
       echo "Snowplow Fractribution integration tests for $model: All tests passed"
     done
-    
+
   else
     echo "Snowplow Fractribution integration tests: Execute fractribution models"
 
-    eval "dbt run --select snowplow_fractribution --target $db --full-refresh" || exit 1;
-    
+    eval "dbt run --select snowplow_fractribution --full-refresh --target $db" || exit 1;
+
     echo "Snowplow Fractribution integration tests: Execute fractribution integration test models"
 
-    eval "dbt run --select snowplow_fractribution_integration_tests --target $db --full-refresh" || exit 1;
+    eval "dbt run --select snowplow_fractribution_integration_tests --full-refresh --target $db" || exit 1;
 
     echo "Snowplow Fractribution integration tests: Test models"
 
-    eval "dbt test --target $db --exclude snowplow_web" || exit 1;
+    eval "dbt test --exclude snowplow_web  --target $db" || exit 1;
 
     echo "Snowplow Fractribution integration tests: All tests passed"
   fi

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_fractribution_integration_tests'
-version: '0.3.1'
+version: '0.3.2'
 config-version: 2
 
 profile: 'integration_tests'

--- a/models/snowplow_fractribution_conversions_by_customer_id.sql
+++ b/models/snowplow_fractribution_conversions_by_customer_id.sql
@@ -24,3 +24,8 @@ from {{ var('snowplow__conversions_source' )}} as events
 where {{ conversion_clause() }}
   and date(derived_tstamp) >= '{{ get_lookback_date_limits("min") }}'
   and date(derived_tstamp) <= '{{ get_lookback_date_limits("max") }}'
+
+  {% if var('snowplow__conversions_source_filter') != '' %}
+    and date({{ var('snowplow__conversions_source_filter') }}) >= {{ dateadd('day',-var('snowplow__conversions_source_filter_buffer_days'), "'"~get_lookback_date_limits('min')~"'") }}
+    and date({{ var('snowplow__conversions_source_filter') }}) <= {{ dateadd('day', var('snowplow__conversions_source_filter_buffer_days'),"'"~get_lookback_date_limits('max')~"'") }}
+  {% endif %}


### PR DESCRIPTION
## Description & motivation
This version gives the option to the user to filter on the timestamp field their events table is partitioned on for query optimization purposes. Unless changed, the `conversions_by_customer_id` model will filter based on `derived_tstamp`.

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)

## Release Only Checklist
- [x] I have updated the version number in all relevant places
- [x] I have updated the CHANGELOG.md 

