### PR TITLE
Release/snowplow fractribution/0.3.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,16 @@
+snowplow-fractribution 0.3.4 (2023-08-17)
+---------------------------------------
+## Summary
+This release adds a couple of features: handling paths that are longer than 256 characters in Redshift, providing the option to filter channels based on which ones to include, and enables automatically setting the conversion window base on the last nth number of complete days within the package.
+
+## Features
+- Increase redshift path inputs to use max varchar instead of default 256 (Close #26)
+- Make conversion_window_start_date more configurable (Close #27)
+- Add channels_to_include variable (Close #28)
+
+## Upgrading
+Bump the snowplow-fractribution version in your `packages.yml` file.
+
 snowplow-fractribution 0.3.3 (2023-07-27)
 ---------------------------------------
 ## Summary

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -35,6 +35,7 @@ vars:
 
     snowplow__consider_intrasession_channels: false # false = only considers the channel at the start (first page view) of the session, true = consider multiple channels in the conversion session as well as historical channels
     snowplow__channels_to_exclude: [] # Channels to exclude before creating path summaries (and therefore excluded from fractribution analysis), e.g. ['Direct']
+    snowplow__channels_to_include: [] # Optional filter on which channels to include when creating path summaries e.g. ['Direct']
     snowplow__use_snowplow_web_user_mapping_table: false # true if using the Snowplow base model for web user mappings (domain_userid => user_id)
 
     # Overwrite these source table vars in your own dbt_project.yml if not using these defaults:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -27,7 +27,8 @@ clean-targets:         # directories to be removed by `dbt clean`
 vars:
   snowplow_fractribution:
     snowplow__conversion_window_start_date: '' # conversion window start date
-    snowplow__conversion_window_end_date: '' # conversion window end date is dynamically set to current_date()-1 in the code
+    snowplow__conversion_window_end_date: '' # conversion window end date
+    snowplow__conversion_window_days: 30 # last complete nth number of days (calculated from the last processed pageview within page_views_source) to dynamically update the conversion_window_start_date and end_date with. Will only apply if both variables are left as an empty string.
     snowplow__conversion_hosts: ['a.com'] # url_hosts to consider
     snowplow__path_transforms: {'exposure_path': null} # dictionary of path transforms (and their argument, null if none) to perform on the full conversion path (see create_udfs.sql)
     snowplow__path_lookback_steps: 0 # Limit for the number of marketing channels to look at before the conversion (0 = unlimited)

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,6 +1,6 @@
 
 name: 'snowplow_fractribution'
-version: '0.3.3'
+version: '0.3.4'
 config-version: 2
 
 require-dbt-version: [">=1.4.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_fractribution_integration_tests'
-version: '0.3.3'
+version: '0.3.4'
 config-version: 2
 
 profile: 'integration_tests'

--- a/integration_tests/models/unit_tests/test_time_limits_actual.sql
+++ b/integration_tests/models/unit_tests/test_time_limits_actual.sql
@@ -1,0 +1,85 @@
+
+/* these test cases should help understand how the upper and lower limits work for developers
+   integration test data when processed by the web model results in '2022-06-03 04:44:32.000' as first_pageview, '2022-08-01 05:37:27.000' as last_pageview
+   illustration: user would like to cover the conversion window between '2022-07-03' and '2022-07-31' (both are inclusive), this covers 29 days
+   using the default 30 days lookback period we should process pageview data from '2022-06-03' */
+
+{% set combined_time = 29 + 30 %}
+
+    with case1 as
+        (with base as (
+            select max(start_tstamp) as last_pageview
+            from {{target.schema}}_derived.snowplow_web_page_views
+         )
+        select cast({{ dbt.dateadd('day', -combined_time, 'last_pageview') }} as date) as result, 'lower_limit' as limit_type, 'sessions' as model_type, 'auto' as update_type, 'case1' as test_case_number
+        from base
+    )
+
+    , case2 as (
+
+        with base as (
+        select cast('2022-07-03' as timestamp) as cw_tstamp
+        )
+        select cast({{ dbt.dateadd('day', -30, 'cw_tstamp' ) }} as date) as result, 'lower_limit' as limit_type, 'sessions' as model_type, 'manual' as update_type, 'case2' as test_case_number
+        from base
+    )
+
+    , case3 as (
+      with base as (
+                select max(start_tstamp) as last_pageview
+                from {{target.schema}}_derived.snowplow_web_page_views
+            )
+        select cast({{ dbt.dateadd('day', -1, 'last_pageview') }} as date) as result, 'upper_limit' as limit_type, 'sessions' as model_type, 'auto' as update_type, 'case3' as test_case_number
+        from base
+
+    )
+
+    , case4 as (
+
+    select cast('2022-07-31' as date) as result, 'upper_limit' as limit_type, 'sessions' as model_type, 'manual' as update_type, 'case4' as test_case_number
+    )
+
+    , case5 as (
+          with base as (
+            select max(start_tstamp) as last_pageview
+            from {{target.schema}}_derived.snowplow_web_page_views
+          )
+        select cast( {{ dbt.dateadd('day', -29, 'last_pageview') }} as date) as result, 'lower_limit' as limit_type, 'conversions' as model_type, 'auto' as update_type, 'case5' as test_case_number
+        from base
+    )
+
+    , case6 as (
+
+    select cast('2022-07-03' as date) as result, 'lower_limit' as limit_type, 'conversions' as model_type, 'manual' as update_type, 'case6' as test_case_number
+    )
+
+    , case7 as (
+
+        with base as (
+                select max(start_tstamp) as last_pageview
+                from {{target.schema}}_derived.snowplow_web_page_views
+            )
+        select cast({{ dbt.dateadd('day', -1, 'last_pageview') }} as date) as result, 'upper_limit' as limit_type, 'conversions' as model_type, 'auto' as update_type, 'case7' as test_case_number
+        from base
+    )
+
+    , case8 as (
+
+        select cast('2022-07-31' as date) as result, 'upper_limit' as limit_type, 'conversions' as model_type, 'manual' as update_type, 'case8' as test_case_number
+    )
+
+    select * from case1
+    union all
+    select * from case2
+    union all
+    select * from case3
+    union all
+    select * from case4
+    union all
+    select * from case5
+    union all
+    select * from case6
+    union all
+    select * from case7
+    union all
+    select * from case8

--- a/integration_tests/models/unit_tests/test_time_limits_expected.sql
+++ b/integration_tests/models/unit_tests/test_time_limits_expected.sql
@@ -1,0 +1,15 @@
+select cast('2022-06-03' as date) as result, 'lower_limit' as limit_type, 'sessions' as model_type, 'auto' as update_type, 'case1' as test_case_number
+union all
+select cast('2022-06-03' as date) as result, 'lower_limit' as limit_type, 'sessions' as model_type, 'manual' as update_type, 'case2' as test_case_number
+union all
+select cast('2022-07-31' as date) as result, 'upper_limit' as limit_type, 'sessions' as model_type, 'auto' as update_type, 'case3' as test_case_number
+union all
+select cast('2022-07-31' as date) as result, 'upper_limit' as limit_type, 'sessions' as model_type, 'manual' as update_type, 'case4' as test_case_number
+union all
+select cast('2022-07-03' as date) as result, 'lower_limit' as limit_type, 'conversions' as model_type, 'auto' as update_type, 'case5' as test_case_number
+union all
+select cast('2022-07-03' as date) as result, 'lower_limit' as limit_type, 'conversions' as model_type, 'manual' as update_type, 'case6' as test_case_number
+union all
+select cast('2022-07-31' as date) as result, 'upper_limit' as limit_type, 'conversions' as model_type, 'auto' as update_type, 'case7' as test_case_number
+union all
+select cast('2022-07-31' as date) as result, 'upper_limit' as limit_type, 'conversions' as model_type, 'manual' as update_type, 'case8' as test_case_number

--- a/integration_tests/models/unit_tests/unit_tests.yml
+++ b/integration_tests/models/unit_tests/unit_tests.yml
@@ -5,3 +5,7 @@ models:
     tests:
       - dbt_utils.equality:
           compare_model: ref('test_path_transformations_expected')
+  - name: test_time_limits_actual
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('test_time_limits_expected')

--- a/macros/get_lookback_date_limits.sql
+++ b/macros/get_lookback_date_limits.sql
@@ -1,17 +1,41 @@
-{% macro get_lookback_date_limits(limit_type) %}
-  {{ return(adapter.dispatch('get_lookback_date_limits', 'snowplow_fractribution')(limit_type)) }}
+{% macro get_lookback_date_limits(limit_type, model) %}
+  {{ return(adapter.dispatch('get_lookback_date_limits', 'snowplow_fractribution')(limit_type, model)) }}
 {% endmacro %}
 
-{% macro default__get_lookback_date_limits(limit_type) %}
+{% macro default__get_lookback_date_limits(limit_type, model) %}
 
-  -- check if web data is up-to-date
-
+  -- check if web data is up-to-date in page_views_source (should cover conversion source check in case the web model is used to model conversions)
+  {% set combined_time = var("snowplow__conversion_window_days") + var('snowplow__path_lookback_days') %}
   {% set query %}
-    select max(start_tstamp) < '{{ var('snowplow__conversion_window_end_date') }}' as is_over_limit,
-           cast(min(start_tstamp) as date) > '{{ var("snowplow__conversion_window_start_date") }}' as is_below_limit,
-           cast(max(start_tstamp) as {{ type_string() }}) as last_processed_page_view,
-           cast(min(start_tstamp) as {{ type_string() }}) as first_processed_page_view
-    from {{ var('snowplow__page_views_source') }}
+
+      -- when the user opts for the auto-populated conversion window
+      {% if var("snowplow__conversion_window_start_date") == '' and var("snowplow__conversion_window_end_date") == '' %}
+           with base as (
+              select max(start_tstamp) as last_pageview,
+                    min(start_tstamp) as first_pageview,
+              from {{ var('snowplow__page_views_source') }}
+           )
+           select
+             false as is_over_limit, -- the last pageview will be taken from the page_views_source
+             cast(first_pageview as date) > cast({{ dbt.dateadd('day', -combined_time, last_pageview) }} as date) as is_below_limit,
+             cast(last_pageview as {{ type_string() }}) as last_processed_page_view,
+             cast(first_pageview as {{ type_string() }}) as first_processed_page_view
+
+      -- when the user opts for manually defined conversion window
+      {% elif var("snowplow__conversion_window_start_date")|length and var("snowplow__conversion_window_end_date")|length %}
+           select
+             max(start_tstamp) < '{{ var('snowplow__conversion_window_end_date') }}' as is_over_limit,
+             cast(min(start_tstamp) as date) > '{{ var("snowplow__conversion_window_start_date") }}' as is_below_limit,
+             cast(max(start_tstamp) as {{ type_string() }}) as last_processed_page_view,
+             cast(min(start_tstamp) as {{ type_string() }}) as first_processed_page_view
+          from {{ var('snowplow__page_views_source') }}
+
+      {% else %}
+        {%- do exceptions.raise_compiler_error("Snowplow Error: please either give both of the following variables a value or set both as empty strings: snowplow__conversion_window_start_date & snowplow__conversion_window_end_date ") %}
+
+
+      {% endif %}
+
   {% endset %}
 
   {% set result = run_query(query) %}
@@ -33,22 +57,65 @@
     {% endif %}
   {% endif %}
 
+  -- setting and executing the limit query depending on input
 
   {% set query %}
-    {% if limit_type == 'min' %}
-      with base as (select case when '{{ var("snowplow__conversion_window_start_date") }}' = ''
-                  then {{ dbt.dateadd('day', -31, dbt.current_timestamp()) }}
-                  else '{{ var("snowplow__conversion_window_start_date") }}'
-                  end as min_date_time)
-      select cast({{ dbt.dateadd('day', (- var('snowplow__path_lookback_days') + 1), 'min_date_time') }} as date) from base
+    {% if limit_type == 'min' and model == 'sessions' %}
+      {% if var("snowplow__conversion_window_start_date") == '' and var("snowplow__conversion_window_end_date") == '' %}
+          with base as (
+            select max(start_tstamp) as last_pageview
+            from {{ var('snowplow__page_views_source') }}
+          )
+          select cast({{ dbt.dateadd('day', -combined_time, 'last_pageview') }} as date) as lower_limit
+          from base
 
+      {% else %}
+         with base as (
+          select cast('{{ var('snowplow__conversion_window_start_date')}}' as timestamp) as cw_tstamp
+         )
+        select cast({{ dbt.dateadd('day', -var('snowplow__path_lookback_days'), 'cw_tstamp' ) }} as date) as lower_limit
+        from base
+      {% endif %}
 
-    {% elif limit_type == 'max' %}
-      with base as (select case when '{{ var("snowplow__conversion_window_start_date") }}' = ''
-                  then {{ dbt.dateadd('day', -1, dbt.current_timestamp()) }}
-                  else '{{ var("snowplow__conversion_window_end_date") }}'
-                  end as max_date_time)
-      select cast(max_date_time as date) from base
+    {% elif limit_type == 'max' and model == 'sessions' %}
+      {% if var("snowplow__conversion_window_start_date") == '' and var("snowplow__conversion_window_end_date") == '' %}
+          with base as (
+                select max(start_tstamp) as last_pageview
+                from {{ var('snowplow__page_views_source') }}
+            )
+        select cast({{ dbt.dateadd('day', -1, 'last_pageview') }} as date) as upper_limit
+        from base
+
+      {% else %}
+        select cast('{{ var("snowplow__conversion_window_end_date") }}' as date) as upper_limit
+      {% endif %}
+
+    {% elif limit_type == 'min' and model == 'conversions' %}
+      {% if var("snowplow__conversion_window_start_date") == '' and var("snowplow__conversion_window_end_date") == '' %}
+         with base as (
+            select max(start_tstamp) as last_pageview
+            from {{ var('snowplow__page_views_source') }}
+         )
+        select cast( {{ dbt.dateadd('day', -var("snowplow__conversion_window_days"), 'last_pageview') }} as date) as lower_limit
+          from base
+
+      {% else %}
+        select cast('{{ var("snowplow__conversion_window_start_date") }}' as date) as lower_limit
+      {% endif %}
+
+    {% elif limit_type == 'max' and model == 'conversions' %}
+      {% if var("snowplow__conversion_window_start_date") == '' and var("snowplow__conversion_window_end_date") == '' %}
+        with base as (
+                select max(start_tstamp) as last_pageview
+                from {{ var('snowplow__page_views_source') }}
+            )
+        select cast({{ dbt.dateadd('day', -1, 'last_pageview') }} as date) as upper_limit
+        from base
+
+      {% else %}
+        select cast('{{ var("snowplow__conversion_window_end_date") }}' as date) as upper_limit
+      {% endif %}
+
     {% else %}
     {% endif %}
   {% endset %}

--- a/macros/path_transformations/create_udfs.sql
+++ b/macros/path_transformations/create_udfs.sql
@@ -180,7 +180,7 @@
   {% set trim_long_path %}
   -- Returns the last snowplow__path_lookback_steps channels in the path if snowplow__path_lookback_steps > 0,
   -- or the full path otherwise.
-  create or replace function {{target.schema}}.trim_long_path(path varchar, snowplow__path_lookback_steps integer)
+  create or replace function {{target.schema}}.trim_long_path(path varchar(max), snowplow__path_lookback_steps integer)
   returns varchar
   stable
   AS $$
@@ -211,7 +211,7 @@
   {% set remove_if_not_all %}
   -- Returns the path with all copies of targetElem removed, unless the path consists only of
   -- targetElems, in which case the original path is returned.
-  create or replace function {{target.schema}}.remove_if_not_all(path varchar, target_elem varchar)
+  create or replace function {{target.schema}}.remove_if_not_all(path varchar(max), target_elem varchar)
   returns varchar
   stable
   AS $$
@@ -237,7 +237,7 @@
   {% set remove_if_last_and_not_all %}
   -- Returns the path with all copies of targetElem removed from the tail, unless the path consists
   -- only of targetElems, in which case the original path is returned.
-  create or replace function {{target.schema}}.remove_if_last_and_not_all(path varchar, target_elem varchar)
+  create or replace function {{target.schema}}.remove_if_last_and_not_all(path varchar(max), target_elem varchar)
   returns varchar
   stable
   AS $$
@@ -268,7 +268,7 @@
   {% set unique %}
   -- Returns the unique/identity transform of the given path array.
   -- E.g. [D, A, B, B, C, D, C, C] --> [D, A, B, B, C, D, C, C].
-  create or replace function {{target.schema}}.unique_path(path varchar)
+  create or replace function {{target.schema}}.unique_path(path varchar(max))
   returns varchar
   stable
   AS $$
@@ -283,7 +283,7 @@
   -- Sequential duplicates are collapsed.
   -- E.g. [D, A, B, B, C, D, C, C] --> [D, A, B, C, D, C].
 
-  create or replace function {{target.schema}}.exposure_path(path varchar)
+  create or replace function {{target.schema}}.exposure_path(path varchar(max))
   returns varchar
   stable
   AS $$
@@ -307,7 +307,7 @@
   -- Returns the first transform of the given path array.
   -- Repeated channels are removed.
   -- E.g. [D, A, B, B, C, D, C, C] --> [D, A, B, C].
-  create or replace function {{target.schema}}.first_path(path varchar)
+  create or replace function {{target.schema}}.first_path(path varchar(max))
   returns varchar
   stable
   AS $$
@@ -330,7 +330,7 @@
   -- Returns the frequency transform of the given path array.
   -- Repeat events are removed, but tracked with a count.
   -- E.g. [D, A, B, B, C, D, C, C] --> [D(2), A(1), B(2), C(3)].
-  create or replace function {{target.schema}}.frequency_path(path varchar)
+  create or replace function {{target.schema}}.frequency_path(path varchar(max))
   returns varchar
   stable
   AS $$

--- a/macros/schema.yml
+++ b/macros/schema.yml
@@ -15,6 +15,9 @@ macros:
       - name: limit_type
         type: string
         description: Can be either 'min' or 'max' depending on if the upper or lower boundary date needs to be returned
+      - name: model
+        type: string
+        description: Can either be 'sessions' for usage within snowplow_fractribution_sessions_by_customer_id or 'conversions' to use for snowplow_fractribution_conversions_by_customer_id
   - name: create_udfs
     description: '{{ doc("macro_create_udfs") }}'
   - name: path_transformation

--- a/models/snowplow_fractribution_conversions_by_customer_id.sql
+++ b/models/snowplow_fractribution_conversions_by_customer_id.sql
@@ -22,10 +22,10 @@ from {{ var('snowplow__conversions_source' )}} as events
 {% endif %}
 
 where {{ conversion_clause() }}
-  and date(derived_tstamp) >= '{{ get_lookback_date_limits("min") }}'
-  and date(derived_tstamp) <= '{{ get_lookback_date_limits("max") }}'
+  and date(derived_tstamp) >= '{{ get_lookback_date_limits("min", "conversions") }}'
+  and date(derived_tstamp) <= '{{ get_lookback_date_limits("max", "conversions") }}'
 
   {% if var('snowplow__conversions_source_filter') != '' %}
-    and date({{ var('snowplow__conversions_source_filter') }}) >= {{ dateadd('day',-var('snowplow__conversions_source_filter_buffer_days'), "'"~get_lookback_date_limits('min')~"'") }}
-    and date({{ var('snowplow__conversions_source_filter') }}) <= {{ dateadd('day', var('snowplow__conversions_source_filter_buffer_days'),"'"~get_lookback_date_limits('max')~"'") }}
+    and date({{ var('snowplow__conversions_source_filter') }}) >= {{ dateadd('day',-var('snowplow__conversions_source_filter_buffer_days'), "'"~get_lookback_date_limits('min', 'conversions')~"'") }}
+    and date({{ var('snowplow__conversions_source_filter') }}) <= {{ dateadd('day', var('snowplow__conversions_source_filter_buffer_days'),"'"~get_lookback_date_limits('max', 'conversions')~"'") }}
   {% endif %}

--- a/models/snowplow_fractribution_sessions_by_customer_id.sql
+++ b/models/snowplow_fractribution_sessions_by_customer_id.sql
@@ -57,7 +57,17 @@ select
   *
 from
   base_data
-{% if var('snowplow__channels_to_exclude') %}
+{% if var('snowplow__channels_to_exclude') and var('snowplow__channels_to_include') %}
     -- Filters out any unwanted channels
     where channel not in ({{ snowplow_utils.print_list(var('snowplow__channels_to_exclude')) }})
+    and channel in ({{ snowplow_utils.print_list(var('snowplow__channels_to_include')) }})
+
+{% elif var('snowplow__channels_to_exclude') %}
+    -- Filters out any unwanted channels
+    where channel not in ({{ snowplow_utils.print_list(var('snowplow__channels_to_exclude')) }})
+
+{% elif var('snowplow__channels_to_include') %}
+    -- Filters out any unwanted channels
+    where channel in ({{ snowplow_utils.print_list(var('snowplow__channels_to_include')) }})
+
 {% endif %}

--- a/models/snowplow_fractribution_sessions_by_customer_id.sql
+++ b/models/snowplow_fractribution_sessions_by_customer_id.sql
@@ -31,9 +31,9 @@ from {{ var('snowplow__page_views_source') }}  page_views
   on page_views.domain_userid = user_mapping.domain_userid
 {% endif %}
 
-where date(derived_tstamp) >= '{{ get_lookback_date_limits("min") }}'
+where date(derived_tstamp) >= '{{ get_lookback_date_limits("min", "sessions") }}'
 
-  and date(derived_tstamp) <= '{{ get_lookback_date_limits("max") }}'
+  and date(derived_tstamp) <= '{{ get_lookback_date_limits("max", "sessions") }}'
 
   and
     -- restrict to certain hostnames


### PR DESCRIPTION
## Description & motivation
This release adds a couple of features: handling paths that are longer than 256 characters in Redshift, providing the option to filter channels based on which ones to include, and enables automatically setting the conversion window base on the last nth number of complete days within the package.

## Features
- Increase redshift path inputs to use max varchar instead of default 256 (Close #26)
- Make conversion_window_start_date more configurable (Close #27)
- Add channels_to_include variable (Close #28)

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have raised a [documentation](https://github.com/snowplow/documentation/pull/581) PR if applicable (Link here if required)

## Release Only Checklist
- [x] I have updated the version number in all relevant places
- [x] I have updated the CHANGELOG.md 

